### PR TITLE
Adds multi select in editor

### DIFF
--- a/packages/core/src/editor.ts
+++ b/packages/core/src/editor.ts
@@ -186,6 +186,8 @@ export const initEditor = function ({
     return source !== 'dblclick'
   })
 
+  editor.on("multiselectnode", (args) => args.accumulate = args.e.ctrlKey || args.e.metaKey);
+
   editor.on(['click'], () => {
     editor.selected.list = []
   })


### PR DESCRIPTION
This adds multi select so you can hold control/command and select many nodes. Clicking and holding on the last node will allow you to drag all selected items.

https://user-images.githubusercontent.com/8985705/209265387-d03e0869-b97e-4e07-9fb8-e40df540cba3.mov

